### PR TITLE
Feature link handling

### DIFF
--- a/3rd-party-licenses/LICENSE-commons-lang.txt
+++ b/3rd-party-licenses/LICENSE-commons-lang.txt
@@ -1,9 +1,26 @@
 Library: commons-lang
+Source code: http://repo1.maven.org/maven2/commons-lang/commons-lang/2.6/commons-lang-2.6-sources.jar
 Copyright 2001-2011 The Apache Software Foundation
+Full copyright text:
+-----------------------------------------------------------------------------------------------------------------------
+Licensed to the Apache Software Foundation (ASF) under one or more
+3contributor license agreements.  See the NOTICE file distributed with
+4this work for additional information regarding copyright ownership.
+5The ASF licenses this file to You under the Apache License, Version 2.0
+6(the "License"); you may not use this file except in compliance with
+7the License.  You may obtain a copy of the License at
+8
+9    http://www.apache.org/licenses/LICENSE-2.0
+10
+11Unless required by applicable law or agreed to in writing, software
+12distributed under the License is distributed on an "AS IS" BASIS,
+13WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+14See the License for the specific language governing permissions and
+15limitations under the License.
+-----------------------------------------------------------------------------------------------------------------------
 License: Apache 2.0
 Full License Text:
 -----------------------------------------------------------------------------------------------------------------------
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/3rd-party-licenses/LICENSE-netty.txt
+++ b/3rd-party-licenses/LICENSE-netty.txt
@@ -1,9 +1,28 @@
 Library: netty
-Copyright 2008-2016 The Netty Project
+Source code: http://central.maven.org/maven2/org/jboss/netty/netty/3.2.8.Final/netty-3.2.8.Final-sources.jar
+The Netty Project - Copyright 2009 Red Hat, Inc
+Full copyright text:
+-----------------------------------------------------------------------------------------------------------------------
+The Netty Project - Copyright 2009 Red Hat, Inc, and is licensed under the
+Apache License version 2.0 as published by the Apache Software Foundation.
+
+A summary of the individual contributors is given below. Any omission should be
+sent to Trustin Lee <trustin@gmail.com>.
+
+SVN Login(s)            Name
+-------------------------------------------------------------------------------
+amit.bhayani@jboss.com  Amit Bhayani
+ataylor                 Andy Taylor
+beve                    Daniel Bevenius
+fredbregier             Frederic Bregier
+trustin                 Trustin Heuiseung Lee
+-------------------------------------------------------------------------------
+
+* JBoss is a registered trademark of Red Hat, Inc.
+-----------------------------------------------------------------------------------------------------------------------
 License: Apache 2.0
 Full License Text:
 -----------------------------------------------------------------------------------------------------------------------
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/3rd-party-licenses/LICENSE-slf4j-api.txt
+++ b/3rd-party-licenses/LICENSE-slf4j-api.txt
@@ -1,9 +1,33 @@
 Library: slf4j-api
+Source code: http://repo2.maven.org/maven2/org/slf4j/slf4j-api/1.7.5/slf4j-api-1.7.5-sources.jar
 Copyright 2004-2013 QOS.ch
+Full copyright text:
+-----------------------------------------------------------------------------------------------------------------------
+Copyright (c) 2004-2013 QOS.ch
+ All rights reserved.
+
+ Permission is hereby granted, free  of charge, to any person obtaining
+ a  copy  of this  software  and  associated  documentation files  (the
+ "Software"), to  deal in  the Software without  restriction, including
+ without limitation  the rights to  use, copy, modify,  merge, publish,
+ distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ permit persons to whom the Software  is furnished to do so, subject to
+ the following conditions:
+ 
+ The  above  copyright  notice  and  this permission  notice  shall  be
+ included in all copies or substantial portions of the Software.
+ 
+ THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ -----------------------------------------------------------------------------------------------------------------------
 License: MIT
 Full License Text:
 -----------------------------------------------------------------------------------------------------------------------
-
 Copyright (c) 2004-2013 QOS.ch
  All rights reserved.
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,202 @@
-Copyright 2016 EMC Corporation. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License").
-You may not use these files except in compliance with the License.
-A copy of the License is located at
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-http://www.apache.org/licenses/LICENSE-2.0.txt
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-or in the "license" file accompanying these files. These files are
-distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-ANY KIND, either express or implied. See the License for the
-specific language governing permissions and limitations under the
-License.
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext.licenseName = 'Apache License, Version 2.0'
 ext.licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
 
 buildscript {
-    ext.commonBuildVersion = '1.5.1'
+    ext.commonBuildVersion = '1.6'
     ext.commonBuildDir = "https://raw.githubusercontent.com/EMCECS/ecs-common-build/v$commonBuildVersion"
     apply from: "$commonBuildDir/ecs-publish.buildscript.gradle", to: buildscript
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,19 @@
-#Tue Jan 05 14:25:15 PST 2016
+#   Copyright 2016 EMC Corporation. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip

--- a/gradlew
+++ b/gradlew
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+#   Copyright 2016 EMC Corporation. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
 
 ##############################################################################
 ##

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,16 @@
+/*
+ * Copyright 2016 EMC Corporation. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 rootProject.name = 'nfsclient'
 include 'tools'

--- a/src/main/java/com/emc/ecs/nfsclient/network/ClientIOHandler.java
+++ b/src/main/java/com/emc/ecs/nfsclient/network/ClientIOHandler.java
@@ -156,7 +156,7 @@ public class ClientIOHandler extends SimpleChannelHandler {
     public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e) throws Exception {
         Throwable cause = e.getCause();
 
-        // don't print exception if it is BindException.
+        // do not print exception if it is BindException.
         // we are trying to search available port below 1024. It is not good to
         // print a flood
         // of error logs during the searching.

--- a/src/main/java/com/emc/ecs/nfsclient/network/RPCRecordDecoder.java
+++ b/src/main/java/com/emc/ecs/nfsclient/network/RPCRecordDecoder.java
@@ -39,7 +39,7 @@ public class RPCRecordDecoder extends FrameDecoder {
     protected Object decode(ChannelHandlerContext channelHandlerContext, Channel channel, ChannelBuffer channelBuffer) throws Exception {
         // Wait until the length prefix is available.
         if (channelBuffer.readableBytes() < 4) {
-            // If null is returned, it means there's not enough data yet.
+            // If null is returned, it means there is not enough data yet.
             // FrameDecoder will call again when there is a sufficient amount of data available.
             return null;
         }

--- a/src/main/java/com/emc/ecs/nfsclient/network/RPCRecordDecoder.java
+++ b/src/main/java/com/emc/ecs/nfsclient/network/RPCRecordDecoder.java
@@ -20,7 +20,7 @@ import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.handler.codec.frame.FrameDecoder;
 
 /**
- * To receive the entire response. We don't actually decode the rpc packet here.
+ * To receive the entire response. We do not actually decode the rpc packet here.
  * Just get the size from the packet and then put them in internal buffer until all data arrive.
  * 
  * @author seibed

--- a/src/main/java/com/emc/ecs/nfsclient/network/RecordMarkingUtil.java
+++ b/src/main/java/com/emc/ecs/nfsclient/network/RecordMarkingUtil.java
@@ -179,7 +179,7 @@ public class RecordMarkingUtil {
      * @param fragmentSize
      *            A long that contains either the int number of bytes in the
      *            fragment, or a special value if this is the last fragment.
-     * @return <code>true</code> if it is, <code>false</code> if it isn't.
+     * @return <code>true</code> if it is, <code>false</code> if it is not.
      */
     static boolean isLastFragment(long fragmentSize) {
         return ((fragmentSize & LAST_FRAG) != 0);

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/Nfs.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/Nfs.java
@@ -260,8 +260,9 @@ public interface Nfs<F extends NfsFile<?, ?>> {
      * @param path
      *            The file's path from the mount point.
      * @return the nfs file object
+     * @throws IOException 
      */
-    F newFile(String path);
+    F newFile(String path) throws IOException;
 
     // RFC 1813 implementation
 

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/NfsResponseBase.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/NfsResponseBase.java
@@ -136,7 +136,7 @@ public abstract class NfsResponseBase extends RpcResponse {
      * 
      * @param xdr
      * @param force
-     *            don't check whether it's there
+     *            do not check whether it's there
      */
     protected void unmarshallingAttributes(Xdr xdr, boolean force) {
         _attributes = makeNfsGetAttributes(xdr, force);
@@ -167,7 +167,7 @@ public abstract class NfsResponseBase extends RpcResponse {
     }
 
     /**
-     * Create the object if it's there, return null if it isn't. Convenience
+     * Create the object if it's there, return null if it is not. Convenience
      * method for use in subclasses.
      * 
      * @param xdr
@@ -184,7 +184,7 @@ public abstract class NfsResponseBase extends RpcResponse {
      * 
      * @param xdr
      * @param force
-     *            don't check whether it's there
+     *            do not check whether it's there
      * @return the created object
      */
     protected static NfsGetAttributes makeNfsGetAttributes(Xdr xdr, boolean force) {

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/NfsResponseBase.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/NfsResponseBase.java
@@ -120,7 +120,7 @@ public abstract class NfsResponseBase extends RpcResponse {
     }
 
     /**
-     * Unmarshall the object if it's there. Convenience method for use in
+     * Unmarshall the object if it is there. Convenience method for use in
      * subclasses.
      * 
      * @param xdr
@@ -130,20 +130,20 @@ public abstract class NfsResponseBase extends RpcResponse {
     }
 
     /**
-     * Unmarshall the object if it's there, or skip the existence check if
+     * Unmarshall the object if it is there, or skip the existence check if
      * <code>force</code> is <code>true</code>. Convenience method for use in
      * subclasses.
      * 
      * @param xdr
      * @param force
-     *            do not check whether it's there
+     *            do not check whether it is there
      */
     protected void unmarshallingAttributes(Xdr xdr, boolean force) {
         _attributes = makeNfsGetAttributes(xdr, force);
     }
 
     /**
-     * Unmarshall the object if it's there. Convenience method for use in
+     * Unmarshall the object if it is there. Convenience method for use in
      * subclasses.
      * 
      * @param xdr
@@ -153,7 +153,7 @@ public abstract class NfsResponseBase extends RpcResponse {
     }
 
     /**
-     * Unmarshall the object if it's there, or skip the existence check if
+     * Unmarshall the object if it is there, or skip the existence check if
      * <code>force</code> is <code>true</code>. Convenience method for use in
      * subclasses.
      * 
@@ -167,7 +167,7 @@ public abstract class NfsResponseBase extends RpcResponse {
     }
 
     /**
-     * Create the object if it's there, return null if it is not. Convenience
+     * Create the object if it is there, return null if it is not. Convenience
      * method for use in subclasses.
      * 
      * @param xdr
@@ -178,13 +178,13 @@ public abstract class NfsResponseBase extends RpcResponse {
     }
 
     /**
-     * Create the object if it's there, or skip the existence check if
+     * Create the object if it is there, or skip the existence check if
      * <code>force</code> is <code>true</code>. Convenience method for use in
      * subclasses.
      * 
      * @param xdr
      * @param force
-     *            do not check whether it's there
+     *            do not check whether it is there
      * @return the created object
      */
     protected static NfsGetAttributes makeNfsGetAttributes(Xdr xdr, boolean force) {

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/NfsWriteRequest.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/NfsWriteRequest.java
@@ -182,7 +182,7 @@ public class NfsWriteRequest extends NfsRequestBase {
      * @return
      *         <ul>
      *         <li><code>true</code> if data is synced</li>
-     *         <li><code>false</code> if it isn't.</li>
+     *         <li><code>false</code> if it is not.</li>
      *         </ul>
      */
     public boolean isSync() {

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/io/LinkTracker.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/io/LinkTracker.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2016 EMC Corporation. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.emc.ecs.nfsclient.nfs.io;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.emc.ecs.nfsclient.nfs.Nfs;
+
+/**
+ * @author seibed
+ *
+ */
+public class LinkTracker<F extends NfsFile<? extends Nfs<F>, F>> {
+
+    /**
+     * Maximum size of a symlink chain to follow.
+     */
+    private static final int MAXSYMLINKS = 40;
+
+    private Set<String> _unresolvedPaths = new HashSet<String>();
+
+    private Map<String, F> _resolvedPaths = new HashMap<String, F>();
+
+    private int linksTraversed = 0;
+
+    public LinkTracker() {}
+
+    final F addLink(String path) throws IOException {
+        if (++linksTraversed > MAXSYMLINKS) {
+            throw new IllegalArgumentException("Too many links to follow (> " + MAXSYMLINKS + ").");
+        }
+
+        F resolvedPath = _resolvedPaths.get(path);
+
+        if (resolvedPath == null) {
+            for (String unresolvedPath : _unresolvedPaths) {
+                if (path.equals(unresolvedPath) || path.startsWith(unresolvedPath + "/")) {
+                    throw new IOException("Links form a loop: " + path);
+                }
+            }
+            _unresolvedPaths.add(path);
+        }
+
+        return resolvedPath;
+    }
+
+    /**
+     * @param path
+     * @param file
+     */
+    public void addResolvedPath(String path, F file) {
+        _resolvedPaths.put(path, file);
+    }
+
+}

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/io/Nfs3File.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/io/Nfs3File.java
@@ -47,10 +47,12 @@ public class Nfs3File extends NfsFileBase<Nfs3, Nfs3File> {
      * @param path
      *            The full path of the file, starting with the mount point.
      * @param linkTracker
-     *            The tracker.
+     *            The tracker to use. This must be passed so that monitoring is
+     *            continued until the link resolves to a file that is not a
+     *            symbolic link.
      * @throws IOException
      */
-    public Nfs3File(Nfs3 nfs, String path, LinkTracker<Nfs3File> linkTracker) throws IOException {
+    public Nfs3File(Nfs3 nfs, String path, LinkTracker<Nfs3, Nfs3File> linkTracker) throws IOException {
         super(nfs, path, linkTracker);
     }
 
@@ -81,7 +83,7 @@ public class Nfs3File extends NfsFileBase<Nfs3, Nfs3File> {
      * 
      * @see com.emc.ecs.nfsclient.nfs.NfsFileBase#newFile(java.lang.String)
      */
-    protected Nfs3File newFile(String path, LinkTracker<Nfs3File> linkTracker) throws IOException {
+    protected Nfs3File newFile(String path, LinkTracker<Nfs3, Nfs3File> linkTracker) throws IOException {
         return new Nfs3File(getNfs(), path, linkTracker);
     }
 

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/io/Nfs3File.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/io/Nfs3File.java
@@ -14,6 +14,8 @@
  */
 package com.emc.ecs.nfsclient.nfs.io;
 
+import java.io.IOException;
+
 import com.emc.ecs.nfsclient.nfs.nfs3.Nfs3;
 
 /**
@@ -31,8 +33,9 @@ public class Nfs3File extends NfsFileBase<Nfs3, Nfs3File> {
      *            The supporting NFS client.
      * @param path
      *            The full path of the file, starting with the mount point.
+     * @throws IOException 
      */
-    public Nfs3File(Nfs3 nfs, String path) {
+    public Nfs3File(Nfs3 nfs, String path) throws IOException {
         super(nfs, path);
     }
 
@@ -43,18 +46,28 @@ public class Nfs3File extends NfsFileBase<Nfs3, Nfs3File> {
      *            The parent file, stored to reduce lookup overhead
      * @param child
      *            The short name of the file, starting from the parent path.
+     * @throws IOException 
      */
-    public Nfs3File(Nfs3File parent, String child) {
+    public Nfs3File(Nfs3File parent, String child) throws IOException {
         super(parent, child);
     }
 
     /*
      * (non-Javadoc)
      * 
-     * @see com.emc.ecs.nfsclient.nfs.NfsFileBase#newChildFile(java.lang.String)
+     * @see com.emc.ecs.nfsclient.nfs.NfsFile#newChildFile(java.lang.String)
      */
-    protected Nfs3File newChildFile(String childName) {
+    public Nfs3File newChildFile(String childName) throws IOException {
         return new Nfs3File(this, childName);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.emc.ecs.nfsclient.nfs.NfsFileBase#newFile(java.lang.String)
+     */
+    protected Nfs3File newFile(String path) throws IOException {
+        return new Nfs3File(getNfs(), path);
     }
 
 }

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/io/Nfs3File.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/io/Nfs3File.java
@@ -36,7 +36,22 @@ public class Nfs3File extends NfsFileBase<Nfs3, Nfs3File> {
      * @throws IOException 
      */
     public Nfs3File(Nfs3 nfs, String path) throws IOException {
-        super(nfs, path);
+        super(nfs, path, null);
+    }
+
+    /**
+     * The basic constructor plus link tracking.
+     * 
+     * @param nfs
+     *            The supporting NFS client.
+     * @param path
+     *            The full path of the file, starting with the mount point.
+     * @param linkTracker
+     *            The tracker.
+     * @throws IOException
+     */
+    public Nfs3File(Nfs3 nfs, String path, LinkTracker<Nfs3File> linkTracker) throws IOException {
+        super(nfs, path, linkTracker);
     }
 
     /**
@@ -66,8 +81,8 @@ public class Nfs3File extends NfsFileBase<Nfs3, Nfs3File> {
      * 
      * @see com.emc.ecs.nfsclient.nfs.NfsFileBase#newFile(java.lang.String)
      */
-    protected Nfs3File newFile(String path) throws IOException {
-        return new Nfs3File(getNfs(), path);
+    protected Nfs3File newFile(String path, LinkTracker<Nfs3File> linkTracker) throws IOException {
+        return new Nfs3File(getNfs(), path, linkTracker);
     }
 
 }

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/io/NfsFile.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/io/NfsFile.java
@@ -120,9 +120,9 @@ public interface NfsFile<N extends Nfs<?>, F extends NfsFile<N, F>> extends Comp
      * Tests whether this client can delete an existing directory entry.
      * Specified by RFC 1813 (https://tools.ietf.org/html/rfc1813).
      *
-     * @return <code>true</code> if it can, <code>false</code> if it can't
+     * @return <code>true</code> if it can, <code>false</code> if it cannot
      * @throws IOException
-     *             if it doesn't exist or permissions can't be read.
+     *             if it does not exist or permissions cannot be read.
      */
     boolean canDelete() throws IOException;
 
@@ -130,9 +130,9 @@ public interface NfsFile<N extends Nfs<?>, F extends NfsFile<N, F>> extends Comp
      * Tests whether this client can execute this file (no meaning for a
      * directory). Specified by RFC 1813 (https://tools.ietf.org/html/rfc1813).
      *
-     * @return <code>true</code> if it can, <code>false</code> if it can't
+     * @return <code>true</code> if it can, <code>false</code> if it cannot
      * @throws IOException
-     *             if it doesn't exist or permissions can't be read.
+     *             if it does not exist or permissions cannot be read.
      */
     boolean canExecute() throws IOException;
 
@@ -140,9 +140,9 @@ public interface NfsFile<N extends Nfs<?>, F extends NfsFile<N, F>> extends Comp
      * Tests whether this client can write new data or add directory entries.
      * Specified by RFC 1813 (https://tools.ietf.org/html/rfc1813).
      *
-     * @return <code>true</code> if it can, <code>false</code> if it can't
+     * @return <code>true</code> if it can, <code>false</code> if it cannot
      * @throws IOException
-     *             if it doesn't exist or permissions can't be read.
+     *             if it does not exist or permissions cannot be read.
      */
     boolean canExtend() throws IOException;
 
@@ -151,9 +151,9 @@ public interface NfsFile<N extends Nfs<?>, F extends NfsFile<N, F>> extends Comp
      * for non-directory objects). Specified by RFC 1813
      * (https://tools.ietf.org/html/rfc1813).
      *
-     * @return <code>true</code> if it can, <code>false</code> if it can't
+     * @return <code>true</code> if it can, <code>false</code> if it cannot
      * @throws IOException
-     *             if it doesn't exist or permissions can't be read.
+     *             if it does not exist or permissions cannot be read.
      */
     boolean canLookup() throws IOException;
 
@@ -162,9 +162,9 @@ public interface NfsFile<N extends Nfs<?>, F extends NfsFile<N, F>> extends Comp
      * existing directory entries. Specified by RFC 1813
      * (https://tools.ietf.org/html/rfc1813).
      *
-     * @return <code>true</code> if it can, <code>false</code> if it can't
+     * @return <code>true</code> if it can, <code>false</code> if it cannot
      * @throws IOException
-     *             if it doesn't exist or permissions can't be read.
+     *             if it does not exist or permissions cannot be read.
      */
     boolean canModify() throws IOException;
 
@@ -172,9 +172,9 @@ public interface NfsFile<N extends Nfs<?>, F extends NfsFile<N, F>> extends Comp
      * Tests whether this client can read data from file or read a directory.
      * Specified by RFC 1813 (https://tools.ietf.org/html/rfc1813).
      *
-     * @return <code>true</code> if it can, <code>false</code> if it can't
+     * @return <code>true</code> if it can, <code>false</code> if it cannot
      * @throws IOException
-     *             if it doesn't exist or permissions can't be read.
+     *             if it does not exist or permissions cannot be read.
      */
     boolean canRead() throws IOException;
 
@@ -209,17 +209,22 @@ public interface NfsFile<N extends Nfs<?>, F extends NfsFile<N, F>> extends Comp
     boolean exists() throws IOException;
 
     /**
-     * @return The backing file obtained by following all symbolic links in the path, if any.
+     * @return The backing file obtained by following all symbolic links in the
+     *         path, if any.
      * @throws IOException
      */
     F followLinks() throws IOException;
 
     /**
      * @param linkTracker
-     * @return The backing file obtained by following all symbolic links in the path, if any.
+     *            The tracker to use. This must be passed so that monitoring is
+     *            continued until the link resolves to a file that is not a
+     *            symbolic link.
+     * @return The backing file obtained by following all symbolic links in the
+     *         path, if any.
      * @throws IOException
      */
-    F followLinks(LinkTracker<?> linkTracker) throws IOException;
+    F followLinks(LinkTracker<N, F> linkTracker) throws IOException;
 
     /**
      * @return The fully qualified path to the file in this network, including
@@ -287,7 +292,7 @@ public interface NfsFile<N extends Nfs<?>, F extends NfsFile<N, F>> extends Comp
      *         </pre>
      * 
      * @throws IOException
-     *             if it doesn't exist or permissions can't be read.
+     *             if it does not exist or permissions cannot be read.
      */
     long getAccess(long accessToCheck) throws IOException;
 
@@ -301,7 +306,7 @@ public interface NfsFile<N extends Nfs<?>, F extends NfsFile<N, F>> extends Comp
     /**
      * @param childName
      * @return The child file.
-     * @throws IOException 
+     * @throws IOException
      */
     F getChildFile(String childName) throws IOException;
 
@@ -375,19 +380,19 @@ public interface NfsFile<N extends Nfs<?>, F extends NfsFile<N, F>> extends Comp
     long getUsableSpace() throws IOException;
 
     /**
-     * @return true if it is, false if it isn't
+     * @return true if it is, false if it is not
      * @throws IOException
      */
     boolean isDirectory() throws IOException;
 
     /**
-     * @return true if it is a normal file, false if it isn't
+     * @return true if it is a normal file, false if it is not
      * @throws IOException
      */
     boolean isFile() throws IOException;
 
     /**
-     * @return true if it is the root file of the mount, false if it isn't
+     * @return true if it is the root file of the mount, false if it is not
      * @throws IOException
      */
     boolean isRootFile() throws IOException;
@@ -399,70 +404,102 @@ public interface NfsFile<N extends Nfs<?>, F extends NfsFile<N, F>> extends Comp
     long lastModified() throws IOException;
 
     /**
-     * @return the length
+     * @return the length in bytes, or 0 if the file does not exist or the
+     *         attributes cannot be read.
      */
     long length();
 
     /**
-     * @return the length
+     * @return the length in bytes
      * @throws IOException
+     *             if the file does not exist or the attributes cannot be read.
      */
     long lengthEx() throws IOException;
 
     /**
+     * Lists all files in this directory.
+     * 
      * @return the names of all files in the directory
      * @throws IOException
      */
     List<String> list() throws IOException;
 
     /**
+     * Lists all files matching the filter in this directory.
+     * 
      * @param filter
-     * @return the names of all files in the directory
+     * @return the names of all files matching the filter in the directory
      * @throws IOException
      */
     List<String> list(NfsFilenameFilter filter) throws IOException;
 
     /**
+     * Lists all files in this directory.
+     * 
      * @return NfsFile objects for all files in the directory
      * @throws IOException
      */
     List<F> listFiles() throws IOException;
 
     /**
+     * Lists all files matching the filter in this directory.
+     * 
      * @param filter
-     * @return NfsFile objects for all files in the directory
+     * @return NfsFile objects for all files matching the filter in the
+     *         directory
      * @throws IOException
      */
     List<F> listFiles(NfsFilenameFilter filter) throws IOException;
 
     /**
+     * Lists all files matching the filter in this directory.
+     * 
      * @param filter
-     * @return NfsFile objects for all files in the directory
+     * @return NfsFile objects for all files matching the filter in the
+     *         directory
      * @throws IOException
      */
     List<F> listFiles(NfsFileFilter filter) throws IOException;
 
     /**
+     * Creates the directory if it does not exist.
+     * 
      * @throws IOException
+     *             if the parent directories do not exist or it cannot be
+     *             created
      */
     void mkdir() throws IOException;
 
     /**
+     * Creates the directory and all parent directories if they do not already
+     * exist.
+     * 
      * @throws IOException
+     *             if it cannot create one of the directories.
      */
     void mkdirs() throws IOException;
 
+    /**
+     * Creates a new file with the current file as its parent directory. This
+     * does not create the file on the NFS mount.
+     * 
+     * @param childName
+     * @return the new file
+     * @throws IOException
+     */
     F newChildFile(String childName) throws IOException;
 
     /**
      * Renames the file denoted by this abstract pathname.
      * 
+     * <p>
      * Many aspects of the behavior of this method are inherently
      * platform-dependent: The rename operation might not be able to move a file
      * from one filesystem to another, it might not be atomic, and it might not
      * succeed if a file with the destination abstract pathname already exists.
      * The return value should always be checked to make sure that the rename
      * operation was successful.
+     * </p>
      * 
      * @param destination
      * @throws IOException
@@ -479,7 +516,21 @@ public interface NfsFile<N extends Nfs<?>, F extends NfsFile<N, F>> extends Comp
     public void setAttributes(NfsSetAttributes nfsSetAttributes) throws IOException;
 
     /**
+     * Sets the last-modified time of the file or directory named by this
+     * abstract pathname.
+     * 
+     * <p>
+     * All platforms support file-modification times to the nearest second, but
+     * some provide more precision. The argument will be truncated to fit the
+     * supported precision. If the operation succeeds and no intervening
+     * operations on the file take place, then the next invocation of the
+     * lastModified() method will return the (possibly truncated) time argument
+     * that was passed to this method.
+     * </p>
+     * 
      * @param millis
+     *            - The new last-modified time, measured in milliseconds since
+     *            the epoch (00:00:00 GMT, January 1, 1970)
      * @throws IOException
      */
     void setLastModified(long millis) throws IOException;

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/io/NfsFile.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/io/NfsFile.java
@@ -215,6 +215,13 @@ public interface NfsFile<N extends Nfs<?>, F extends NfsFile<N, F>> extends Comp
     F followLinks() throws IOException;
 
     /**
+     * @param linkTracker
+     * @return The backing file obtained by following all symbolic links in the path, if any.
+     * @throws IOException
+     */
+    F followLinks(LinkTracker<?> linkTracker) throws IOException;
+
+    /**
      * @return The fully qualified path to the file in this network, including
      *         the server name and the exported folders, using the usual form:
      *         <code>server:exported_folders/path_from_exported_filesystem_root</code>

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/io/NfsFile.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/io/NfsFile.java
@@ -209,6 +209,12 @@ public interface NfsFile<N extends Nfs<?>, F extends NfsFile<N, F>> extends Comp
     boolean exists() throws IOException;
 
     /**
+     * @return The backing file obtained by following all symbolic links in the path, if any.
+     * @throws IOException
+     */
+    F followLinks() throws IOException;
+
+    /**
      * @return The fully qualified path to the file in this network, including
      *         the server name and the exported folders, using the usual form:
      *         <code>server:exported_folders/path_from_exported_filesystem_root</code>
@@ -288,8 +294,9 @@ public interface NfsFile<N extends Nfs<?>, F extends NfsFile<N, F>> extends Comp
     /**
      * @param childName
      * @return The child file.
+     * @throws IOException 
      */
-    F getChildFile(String childName);
+    F getChildFile(String childName) throws IOException;
 
     /**
      * @return The number of unallocated bytes in the partition named by this
@@ -373,6 +380,12 @@ public interface NfsFile<N extends Nfs<?>, F extends NfsFile<N, F>> extends Comp
     boolean isFile() throws IOException;
 
     /**
+     * @return true if it is the root file of the mount, false if it isn't
+     * @throws IOException
+     */
+    boolean isRootFile() throws IOException;
+
+    /**
      * @return time of last modification
      * @throws IOException
      */
@@ -431,6 +444,8 @@ public interface NfsFile<N extends Nfs<?>, F extends NfsFile<N, F>> extends Comp
      * @throws IOException
      */
     void mkdirs() throws IOException;
+
+    F newChildFile(String childName) throws IOException;
 
     /**
      * Renames the file denoted by this abstract pathname.

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/io/NfsFileBase.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/io/NfsFileBase.java
@@ -1287,7 +1287,7 @@ public abstract class NfsFileBase<N extends Nfs<F>, F extends NfsFile<N, F>> imp
      *            continued until the link resolves to a file that is not a
      *            symbolic link.
      * @throws IOException
-     *             if links can't be followed.
+     *             if links cannot be followed.
      */
     private void setParentFileAndName(F parentFile, String name, LinkTracker<N, F> linkTracker) throws IOException {
         if (parentFile != null) {

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/io/NfsFileInputStream.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/io/NfsFileInputStream.java
@@ -94,12 +94,12 @@ public class NfsFileInputStream extends InputStream {
     public NfsFileInputStream(NfsFile<?, ?> nfsFile, long offset, int maximumBufferSize) throws IOException {
         // Validate the offset.
         if (offset < 0) {
-            throw new IllegalArgumentException("Can't start reading before offset 0: " + offset);
+            throw new IllegalArgumentException("Cannot start reading before offset 0: " + offset);
         }
 
         // Validate the maximum buffer size.
         if (maximumBufferSize <= 0) {
-            throw new IllegalArgumentException("Can't have a maximum buffer size <= 0: " + maximumBufferSize);
+            throw new IllegalArgumentException("Cannot have a maximum buffer size <= 0: " + maximumBufferSize);
         }
 
         // Validate the file.
@@ -140,7 +140,8 @@ public class NfsFileInputStream extends InputStream {
     /**
      * Creates a <code>NfsFileInputStream</code> by opening a connection to an
      * actual NFS file, starting to read at offset 0 and using the preferred
-     * buffer size as the maximums.
+     * buffer size as the maximums. This constructor will generally give you the
+     * best performance.
      * <p>
      * If the named file does not exist, is a directory rather than a regular
      * file, or for some other reason cannot be opened for reading then a

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/io/NfsFileOutputStream.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/io/NfsFileOutputStream.java
@@ -69,7 +69,7 @@ public class NfsFileOutputStream extends OutputStream {
     private int _bufferOffset = 0;
 
     /**
-     * Flag to make sure operations aren't run after closing the stream.
+     * Flag to make sure operations are not run after closing the stream.
      */
     private boolean _closed = false;
 
@@ -147,7 +147,7 @@ public class NfsFileOutputStream extends OutputStream {
     public NfsFileOutputStream(NfsFile<?, ?> nfsFile, long offset, int syncType) throws IOException {
         // Validate the offset.
         if (offset < 0) {
-            throw new IllegalArgumentException("Can't start writing before offset 0: " + offset);
+            throw new IllegalArgumentException("Cannot start writing before offset 0: " + offset);
         }
 
         // Validate the syncType value.

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/nfs3/Nfs3.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/nfs3/Nfs3.java
@@ -361,7 +361,7 @@ public class Nfs3 implements Nfs<Nfs3File> {
             }
         }
 
-        // unmount it, so the server knows we aren't holding on to it
+        // unmount it, so the server knows we are not holding on to it
         UnmountRequest unmountRequest = new UnmountRequest(VERSION, _exportedPath, _credential);
         for (int i = 0; i < MOUNT_MAX_RETRIES; ++i) {
             try {
@@ -379,7 +379,7 @@ public class Nfs3 implements Nfs<Nfs3File> {
             }
         }
 
-        // If this gets here, the response can't be null.
+        // If this gets here, the response cannot be null.
         // log the security mode that NFS supports, though we just
         // support AUTH_UNIX now
         int[] authenticationFlavors = response.getAuthenticationFlavors();

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/nfs3/Nfs3.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/nfs3/Nfs3.java
@@ -459,7 +459,7 @@ public class Nfs3 implements Nfs<Nfs3File> {
     /* (non-Javadoc)
      * @see com.emc.ecs.nfsclient.nfs.Nfs#newFile(java.lang.String)
      */
-    public Nfs3File newFile(String path) {
+    public Nfs3File newFile(String path) throws IOException {
         return new Nfs3File(this, path);
     }
 

--- a/src/main/java/com/emc/ecs/nfsclient/rpc/CredentialUnix.java
+++ b/src/main/java/com/emc/ecs/nfsclient/rpc/CredentialUnix.java
@@ -122,7 +122,7 @@ public class CredentialUnix extends CredentialBase {
     }
 
     /**
-     * @return The hostname, or "localhost" if it can't be determined.
+     * @return The hostname, or "localhost" if it cannot be determined.
      */
     private static String getHostname() {
         try {
@@ -131,7 +131,7 @@ public class CredentialUnix extends CredentialBase {
             // do nothing
         }
 
-        // the hostname doesn't affect the correctness of RPC call, so
+        // the hostname does not affect the correctness of RPC call, so
         // just return "localhost" if cannot get the host name
         return "localhost";
     }

--- a/src/main/java/com/emc/ecs/nfsclient/rpc/Xdr.java
+++ b/src/main/java/com/emc/ecs/nfsclient/rpc/Xdr.java
@@ -219,8 +219,8 @@ public class Xdr {
 
     /*
      * Note: we have no XDR routines for encoding/decoding unsigned longs. They
-     * exist in XDR but not in Java hence we can't represent them. Best just to
-     * use xdr_hyper() and hope the sign bit isn't used.
+     * exist in XDR but not in Java hence we cannot represent them. Best just to
+     * use xdr_hyper() and hope the sign bit is not used.
      */
 
     /**

--- a/src/test/java/com/emc/ecs/nfsclient/NfsTestBase.java
+++ b/src/test/java/com/emc/ecs/nfsclient/NfsTestBase.java
@@ -106,7 +106,7 @@ public class NfsTestBase extends Assert {
     }
 
     /**
-     * Loads the default properties, throws an exception if they can't be
+     * Loads the default properties, throws an exception if they cannot be
      * loaded.
      * 
      * @return The properties.


### PR DESCRIPTION
This adds code to handle symbolic links in NfsFile paths in a more or less intuitive manner.
- They are automatically resolved whenever needed to support directory operations.
- A followLinks() method was added to allow users to force link resolution when needed for other calls.
