### PR TITLE
Fix a bug when the byte read is -1. Old behavior was thinking …

### DIFF
--- a/src/main/java/com/emc/ecs/nfsclient/nfs/io/NfsFileInputStream.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/io/NfsFileInputStream.java
@@ -218,7 +218,8 @@ public class NfsFileInputStream extends InputStream {
         if (bytesRead == EOF) {
             return EOF;
         } else {
-            return b[0];
+        //byte type in Java is from -128 to +127 and we are supposed to return 0-255
+            return b[0] & 0xFF;
         }
     }
 


### PR DESCRIPTION
… that EOF is reached, while in fact the byte read was = -1, now we convert the byte to 0-255 range as per java.io.InputStream#read() contract.