### PR TITLE
Pull request for combined inputs to guard time functionality

### DIFF
--- a/src/main/java/com/emc/ecs/nfsclient/nfs/NfsSetAttrRequest.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/NfsSetAttrRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 EMC Corporation. All Rights Reserved.
+ * Copyright 2016-2018 EMC Corporation. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -64,6 +64,9 @@ public class NfsSetAttrRequest extends NfsRequestBase {
             int nfsVersion) throws FileNotFoundException {
         super(Nfs.RPC_PROGRAM, nfsVersion, Nfs.NFSPROC3_SETATTR, credential, fileHandle);
         _attributes = attributes;
+        if ( ( guardTime != null ) && ( ! guardTime.isBareTime() ) ) {
+            throw new IllegalArgumentException("The guard time cannot be a time setting time");
+        }
         _guardTime = guardTime;
     }
 
@@ -80,8 +83,7 @@ public class NfsSetAttrRequest extends NfsRequestBase {
             xdr.putBoolean(false);
         } else {
             xdr.putBoolean(true);
-            xdr.putUnsignedInt(_guardTime.getSeconds());
-            xdr.putUnsignedInt(_guardTime.getNanoseconds());
+            _guardTime.marshalling(xdr);
         }
     }
 

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/NfsSetAttributes.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/NfsSetAttributes.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 EMC Corporation. All Rights Reserved.
+ * Copyright 2016-2018 EMC Corporation. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -132,6 +132,9 @@ public class NfsSetAttributes {
      *            the time when the file data was last accessed.
      */
     public void setAtime(NfsTime atime) {
+        if ( atime != null && atime.isBareTime() ) {
+            throw new IllegalArgumentException("The atime must be a time setting time");
+        }
         _atime = atime;
     }
 
@@ -140,6 +143,9 @@ public class NfsSetAttributes {
      *            the time when the file data was last modified.
      */
     public void setMtime(NfsTime mtime) {
+        if ( mtime != null && mtime.isBareTime() ) {
+            throw new IllegalArgumentException("The mtime must be a time setting time");
+        }
         _mtime = mtime;
     }
 
@@ -178,8 +184,8 @@ public class NfsSetAttributes {
         _uid = uid;
         _gid = gid;
         _size = size;
-        _atime = atime;
-        _mtime = mtime;
+        setAtime( atime );
+        setMtime( mtime );
     }
 
     /**

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/NfsTime.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/NfsTime.java
@@ -50,7 +50,7 @@ public class NfsTime implements NfsRequest, NfsResponse {
     /**
      * This usually indicates a guard time - attributes should be changed only
      * if the object's ctime matches the associated time, as specified by RFC
-     * 1813 (https://tools.ietf.org/html/rfc1813). The 
+     * 1813 (https://tools.ietf.org/html/rfc1813).
      */
     private static final int IS_BARE_TIME = -1;
 
@@ -138,7 +138,7 @@ public class NfsTime implements NfsRequest, NfsResponse {
      * @see com.emc.ecs.nfsclient.nfs.NfsRequest#marshalling(com.emc.ecs.nfsclient.rpc.Xdr)
      */
     public void marshalling(Xdr xdr) {
-        if ( IS_BARE_TIME != _timeSettingType ) {
+        if ( !isBareTime() ) {
             xdr.putInt(_timeSettingType);
         }
         if ( captureTime() ) {
@@ -166,8 +166,8 @@ public class NfsTime implements NfsRequest, NfsResponse {
      * @return true if the time in milliseconds will be used, false otherwise.
      */
     private boolean captureTime() {
-        return ( ( SET_TO_CLIENT_TIME == _timeSettingType )
-              || ( IS_BARE_TIME == _timeSettingType ) );
+        return ( isBareTime() 
+              || ( SET_TO_CLIENT_TIME == _timeSettingType ) );
     }
 
 }

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/NfsTime.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/NfsTime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 EMC Corporation. All Rights Reserved.
+ * Copyright 2016-2018 EMC Corporation. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -48,6 +48,13 @@ public class NfsTime implements NfsRequest, NfsResponse {
     private static final int SET_TO_CLIENT_TIME = 2;
 
     /**
+     * This usually indicates a guard time - attributes should be changed only
+     * if the object's ctime matches the associated time, as specified by RFC
+     * 1813 (https://tools.ietf.org/html/rfc1813). The 
+     */
+    private static final int IS_BARE_TIME = -1;
+
+    /**
      * This constant is the NfsTime passed to setters to indicate that the time
      * should not be changed.
      */
@@ -71,24 +78,45 @@ public class NfsTime implements NfsRequest, NfsResponse {
     }
 
     /**
-     * Create a new NfsTime for the time corresponding to milliseconds.
+     * Create a new NfsTime for the setting time corresponding to milliseconds.
      * 
      * @param milliseconds
      *            same as for java.util.Date.
      */
     public NfsTime(long milliseconds) {
-        this(milliseconds, SET_TO_CLIENT_TIME);
+        this(milliseconds, true);
+    }
+
+    /**
+     * Create a new NfsTime for the setting or guard time corresponding to milliseconds.
+     * 
+     * @param milliseconds
+     *            same as for java.util.Date.
+     * @param isSettingTime
+     *            true if the time is to be used for setting a value,
+     *            false if not (e.g., guard time)
+     */
+    public NfsTime(long milliseconds, boolean isSettingTime) {
+        this(milliseconds, isSettingTime ? SET_TO_CLIENT_TIME : IS_BARE_TIME);
     }
 
     private NfsTime(long milliseconds, int timeSettingType) {
         _timeSettingType = timeSettingType;
-        if (SET_TO_CLIENT_TIME == timeSettingType) {
+        if ( captureTime() ) {
             seconds = milliseconds / 1000;
             nanoseconds = (milliseconds - seconds * 1000) * 1000000;
         } else {
             seconds = 0;
             nanoseconds = 0;
         }
+    }
+
+    /**
+     * @return true if this is a bare time (with no time setting type), false
+     * otherwise.
+     */
+    public boolean isBareTime() {
+        return IS_BARE_TIME == _timeSettingType;
     }
 
     /*
@@ -110,8 +138,10 @@ public class NfsTime implements NfsRequest, NfsResponse {
      * @see com.emc.ecs.nfsclient.nfs.NfsRequest#marshalling(com.emc.ecs.nfsclient.rpc.Xdr)
      */
     public void marshalling(Xdr xdr) {
-        xdr.putInt(_timeSettingType);
-        if (SET_TO_CLIENT_TIME == _timeSettingType) {
+        if ( IS_BARE_TIME != _timeSettingType ) {
+            xdr.putInt(_timeSettingType);
+        }
+        if ( captureTime() ) {
             xdr.putUnsignedInt(seconds);
             xdr.putUnsignedInt(nanoseconds);
         }
@@ -133,16 +163,11 @@ public class NfsTime implements NfsRequest, NfsResponse {
     }
 
     /**
-     * @return the seconds value
+     * @return true if the time in milliseconds will be used, false otherwise.
      */
-    public long getSeconds() {
-        return seconds;
+    private boolean captureTime() {
+        return ( ( SET_TO_CLIENT_TIME == _timeSettingType )
+              || ( IS_BARE_TIME == _timeSettingType ) );
     }
 
-    /**
-     * @return the nanoseconds value
-     */
-    public long getNanoseconds() {
-        return nanoseconds;
-    }
 }

--- a/src/test/java/com/emc/ecs/nfsclient/nfs/nfs3/Test_Nfs3.java
+++ b/src/test/java/com/emc/ecs/nfsclient/nfs/nfs3/Test_Nfs3.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 EMC Corporation. All Rights Reserved.
+ * Copyright 2016-2018 EMC Corporation. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -73,15 +73,22 @@ public class Test_Nfs3 extends NfsTestBase {
         assertEquals(NfsStatus.NFS3_OK.getValue(), createRes.getState());
 
         try {
-            NfsTime ctime = createRes.getAttributes().getCtime();
+            NfsTime guardTime = new NfsTime( createRes.getAttributes().getCtime().getTimeInMillis(), false );
             Nfs3SetAttrResponse setAttrResponse = nfs3.setAttr(new NfsSetAttrRequest(createRes.getFileHandle(),
                     new NfsSetAttributes(null, null, null, new Long(1024), null, null),
-                    ctime,
+                    guardTime,
                     new CredentialUnix(), 3));
 
             assertEquals(NfsStatus.NFS3_OK.getValue(), setAttrResponse.getState());
-        }
-        finally {
+
+            guardTime = new NfsTime( 0, false );
+            setAttrResponse = nfs3.setAttr(new NfsSetAttrRequest(createRes.getFileHandle(),
+                    new NfsSetAttributes(null, null, null, new Long(1024), null, null),
+                    guardTime,
+                    new CredentialUnix(), 3));
+
+            assertEquals(NfsStatus.NFS3ERR_NOT_SYNC.getValue(), setAttrResponse.getState());
+        } finally {
             // Clean up file
             nfs3.sendRemove(new NfsRemoveRequest(rootHandle, TEST_FILE_NAME, new CredentialUnix(), 3));
         }


### PR DESCRIPTION
Any comments on this version, @amarcionek ? This should contain the same changes, with some of the class hierarchy changes but also preserving backwards compatibility for all code that doesn't use  guard time. I didn't worry about the guard time code, since that wasn't working before the fix. I did tighten up input checking, so that clear exceptions would be raised immediately if code used the wrong time type.