### PR TITLE
Client fix

### DIFF
--- a/src/main/java/com/emc/ecs/nfsclient/nfs/io/NfsFileOutputStream.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/io/NfsFileOutputStream.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2016-2018 Dell Inc. or its subsidiaries. All rights reserved.
+package com.emc.ecs.nfsclient.nfs.io; /**
+ * Copyright 2016 EMC Corporation. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -12,21 +12,19 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-package com.emc.ecs.nfsclient.nfs.io;
 
 import com.emc.ecs.nfsclient.nfs.NfsCreateMode;
 import com.emc.ecs.nfsclient.nfs.NfsSetAttributes;
 import com.emc.ecs.nfsclient.nfs.NfsWriteRequest;
 import com.emc.ecs.nfsclient.nfs.NfsWriteResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The NFS equivalent of <code>java.io.FileOutputStream</code>.
@@ -82,6 +80,13 @@ public class NfsFileOutputStream extends OutputStream {
     private boolean _closed = false;
 
     /**
+     * The buffer size specified by the user when calling the write(byte[])
+     * 8K is enough for all metadata and A send operation can be avoided to
+     * the maximum extent when the user does not specify the bufferSize parameter.
+     */
+    private static final int bufferSize = 8 * 1024;
+
+    /**
      * Creates a file output stream to write to the file represented by the
      * specified <code>NfsFile</code> object, starting at
      * <code>offset = 0</code> and using <code>syncType = FILE_SYNC</code>
@@ -97,7 +102,7 @@ public class NfsFileOutputStream extends OutputStream {
      *             opened for any other reason
      */
     public NfsFileOutputStream(NfsFile<?, ?> nfsFile) throws IOException {
-        this(nfsFile, 0, NfsWriteRequest.FILE_SYNC);
+        this(nfsFile, 0, NfsWriteRequest.FILE_SYNC, bufferSize);
     }
 
     /**
@@ -124,7 +129,36 @@ public class NfsFileOutputStream extends OutputStream {
      *             opened for any other reason
      */
     public NfsFileOutputStream(NfsFile<?, ?> nfsFile, int syncType) throws IOException {
-        this(nfsFile, 0, syncType);
+        this(nfsFile, syncType, bufferSize);
+    }
+
+    /**
+     * Creates a file output stream to write to the file represented by the
+     * specified <code>NfsFile</code> object, starting at
+     * <code>offset = 0</code> and using <code>syncType</code> behavior.
+     * <p>
+     * If the file does not exist, it will first be created.
+     *
+     * @param nfsFile
+     *            The file to be opened for writing.
+     * @param syncType
+     *            One of the values below.
+     *            <ul>
+     *            <li>UNSTABLE = 0 - Best effort, no promises.</li>
+     *            <li>DATA_SYNC = 1 - Commit all data to stable storage, plus
+     *            enough metadata for retrieval, before returning.</li>
+     *            <li>FILE_SYNC = 2 - Commit all data and metadata to stable
+     *            storage before returning.</li>
+     *            </ul>
+     * @param  bufferSize
+     *            The buffer size specified by the user when calling the write(byte[])
+     * @throws IOException
+     *             If the file exists but is a directory rather than a regular
+     *             file, does not exist but cannot be created, or cannot be
+     *             opened for any other reason
+     */
+    public NfsFileOutputStream(NfsFile<?, ?> nfsFile, int syncType, int bufferSize) throws IOException {
+        this(nfsFile, 0, syncType, bufferSize);
     }
 
     /**
@@ -147,12 +181,14 @@ public class NfsFileOutputStream extends OutputStream {
      *            <li>FILE_SYNC = 2 - Commit all data and metadata to stable
      *            storage before returning.</li>
      *            </ul>
+     * @param  bufferSize
+     *            The buffer size specified by the user when calling the write(byte[])
      * @throws IOException
      *             If the file exists but is a directory rather than a regular
      *             file, does not exist but cannot be created, or cannot be
      *             opened for any other reason
      */
-    public NfsFileOutputStream(NfsFile<?, ?> nfsFile, long offset, int syncType) throws IOException {
+    public NfsFileOutputStream(NfsFile<?, ?> nfsFile, long offset, int syncType, int bufferSize) throws IOException {
         // Validate the offset.
         if (offset < 0) {
             throw new IllegalArgumentException("Cannot start writing before offset 0: " + offset);
@@ -184,7 +220,8 @@ public class NfsFileOutputStream extends OutputStream {
         _offset = offset;
         _currentOffset = offset;
         _syncType = syncType;
-        _buffer = new byte[(int) Math.min(_nfsFile.fsinfo().getFsInfo().wtpref, Integer.MAX_VALUE)];
+        _buffer = new byte[(int) Math.min(_nfsFile.fsinfo().getFsInfo().wtpref, Integer.MAX_VALUE) - bufferSize];
+        //_buffer = new byte[1024 * 1020];
     }
 
     /*
@@ -243,6 +280,10 @@ public class NfsFileOutputStream extends OutputStream {
      * @see java.io.OutputStream#write(byte[], int, int)
      */
     public void write(byte[] b, int off, int len) throws IOException {
+        System.out.println("开始写入数据！");
+        System.out.println("_buffer:" + _buffer.length);
+        System.out.println("wtmax:" + _nfsFile.fsinfo().getFsInfo().wtmax);
+
         checkForClosed();
         if (b == null) {
             throw new NullPointerException();
@@ -252,13 +293,16 @@ public class NfsFileOutputStream extends OutputStream {
             return;
         }
         if (len > bytesLeftInBuffer()) {
+            System.out.println("进入if");
             int bytesToWrite = bytesLeftInBuffer();
             write(b, off, bytesToWrite);
             write(b, off + bytesToWrite, len - bytesToWrite);
         } else {
             System.arraycopy(b, off, _buffer, _bufferOffset, len);
             _bufferOffset += len;
+            System.out.println("bytesLeftInBuffer:" + bytesLeftInBuffer());
             if (bytesLeftInBuffer() == 0) {
+                System.out.println("准备进入writeBufferToFile()");
                 writeBufferToFile();
             }
         }
@@ -290,11 +334,13 @@ public class NfsFileOutputStream extends OutputStream {
      * @throws IOException
      */
     private void writeBufferToFile() throws IOException {
+        System.out.println("开始写入缓冲区数据到文件中！");
         if (_bufferOffset > 0) {
             List<ByteBuffer> payload = new ArrayList<ByteBuffer>(1);
             payload.add(ByteBuffer.wrap(_buffer, 0, _bufferOffset));
             NfsWriteResponse response = _nfsFile.write(_currentOffset, payload, _syncType);
             int bytesWritten = response.getCount();
+            System.out.println("写入的数据为：" + bytesWritten);
             _currentOffset += bytesWritten;
             _bufferOffset -= bytesWritten;
             if (0 != _bufferOffset) { // Everything was not written.

--- a/src/main/java/com/emc/ecs/nfsclient/nfs/io/NfsFileOutputStream.java
+++ b/src/main/java/com/emc/ecs/nfsclient/nfs/io/NfsFileOutputStream.java
@@ -80,7 +80,7 @@ public class NfsFileOutputStream extends OutputStream {
     private boolean _closed = false;
 
     /**
-     * The buffer size specified by the user when calling the write(byte[])
+     * The buffer size specified by the user when calling the write()
      * 8K is enough for all metadata and A send operation can be avoided to
      * the maximum extent when the user does not specify the bufferSize parameter.
      */


### PR DESCRIPTION
When using nfs-client to transfer a file greater than 1024 * 1024, the following error occurs: 
**_Tcp IO error on the connection_**,the reason for this may be that the pipeline reader is closed, **_BROKEN PIPE_** error is generated, and Tcp IO error exception is thrown. Because the server source code is not clear, my guess about this problem is as follows: 
In **_channel.write ()_**, the **_CompositeChannelBuffer_** is sent as a message. The size of the message is limited to 1024 * 1024 on the server, while in **_NfsFileOutputStream_**, **__ buffer_** is the byte array that actually stores the data (size 1024 * 1024), which must be filled before the data is sent. 
But,**_message = metadata + data._** 
So one possibility is that the server limits the size of an overall message, while message contains metadata, so the actual data carried can only be less than 1024 * 1024. 
So I think one way to solve bug is to adjust the default size of _**_ buffer**_: 
**__ buffer = new byte [(int) Math.min (_ nfsFile.fsinfo () .getFsInfo () .wtpref, Integer.MAX_VALUE)-bufferSize]._** 
Set aside some space for metadata storage to ensure that the whole message is not greater than 1024 * 1024