### PR TITLE
Fix bug of handle large rpc call response

### DIFF
--- a/src/main/java/com/emc/ecs/nfsclient/network/RPCRecordDecoder.java
+++ b/src/main/java/com/emc/ecs/nfsclient/network/RPCRecordDecoder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016-2018 Dell Inc. or its subsidiaries. All rights reserved.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0.txt
- *
+ * <p>
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -22,7 +22,7 @@ import org.jboss.netty.handler.codec.frame.FrameDecoder;
 /**
  * To receive the entire response. We do not actually decode the rpc packet here.
  * Just get the size from the packet and then put them in internal buffer until all data arrive.
- * 
+ *
  * @author seibed
  */
 public class RPCRecordDecoder extends FrameDecoder {
@@ -32,6 +32,9 @@ public class RPCRecordDecoder extends FrameDecoder {
      * Reset to 0 after that for the next channel.
      */
     private int _recordLength = 0;
+
+    // To hold the real position of fragment starts
+    private int _realReaderIndex = 0;
 
     /* (non-Javadoc)
      * @see org.jboss.netty.handler.codec.frame.FrameDecoder#decode(org.jboss.netty.channel.ChannelHandlerContext, org.jboss.netty.channel.Channel, org.jboss.netty.buffer.ChannelBuffer)
@@ -46,7 +49,7 @@ public class RPCRecordDecoder extends FrameDecoder {
 
         //marking the current reading position
         channelBuffer.markReaderIndex();
-
+        channelBuffer.skipBytes(_realReaderIndex);
         //get the fragment size and wait until the entire fragment is available.
         long fragSize = channelBuffer.readUnsignedInt();
         boolean lastFragment = RecordMarkingUtil.isLastFragment(fragSize);
@@ -61,17 +64,24 @@ public class RPCRecordDecoder extends FrameDecoder {
 
         _recordLength += 4 + (int) fragSize;
 
+        System.out.println("[test]current realindex=" + _realReaderIndex + " readerIndex=" + channelBuffer.readerIndex() + " length=" + _recordLength + " fragSize=" + fragSize + " readable=" + channelBuffer.readableBytes());
+
         //check the last fragment
         if (!lastFragment) {
+            channelBuffer.resetReaderIndex();
+            _realReaderIndex += 4 + (int) fragSize;
             //not the last fragment, the data is put in an internally maintained cumulative buffer
             return null;
         }
-
+        System.out.println("[test]is last");
         byte[] rpcResponse = new byte[_recordLength];
+
         channelBuffer.readerIndex(channelBuffer.readerIndex() - _recordLength);
+
         channelBuffer.readBytes(rpcResponse, 0, _recordLength);
 
         _recordLength = 0;
+        _realReaderIndex = 0;
         return rpcResponse;
     }
 }

--- a/src/main/java/com/emc/ecs/nfsclient/network/RPCRecordDecoder.java
+++ b/src/main/java/com/emc/ecs/nfsclient/network/RPCRecordDecoder.java
@@ -64,8 +64,6 @@ public class RPCRecordDecoder extends FrameDecoder {
 
         _recordLength += 4 + (int) fragSize;
 
-        System.out.println("[test]current realindex=" + _realReaderIndex + " readerIndex=" + channelBuffer.readerIndex() + " length=" + _recordLength + " fragSize=" + fragSize + " readable=" + channelBuffer.readableBytes());
-
         //check the last fragment
         if (!lastFragment) {
             channelBuffer.resetReaderIndex();
@@ -73,7 +71,6 @@ public class RPCRecordDecoder extends FrameDecoder {
             //not the last fragment, the data is put in an internally maintained cumulative buffer
             return null;
         }
-        System.out.println("[test]is last");
         byte[] rpcResponse = new byte[_recordLength];
 
         channelBuffer.readerIndex(channelBuffer.readerIndex() - _recordLength);

--- a/src/main/java/com/emc/ecs/nfsclient/network/RecordMarkingUtil.java
+++ b/src/main/java/com/emc/ecs/nfsclient/network/RecordMarkingUtil.java
@@ -139,7 +139,7 @@ public class RecordMarkingUtil {
             fragSize = maskFragmentSize(fragSize);
 
             toReturn.putBytes(input.getBuffer(), input.getOffset(), (int) fragSize);
-            inputOff += fragSize;
+            inputOff += 4 + fragSize;
             input.setOffset(inputOff);
         }
 


### PR DESCRIPTION
If the response of rpc call is separate into serval fragments, will trying to hold them and merge into ONE buffer.
    
This bug will happen when using this client to download large files.

Here is some log when I download a file with 160MB. It has a large rpc call, and separated  into 9 fragments. In old version,
_recordLength is adds up but buffer didn't hold bytes all
![image](https://user-images.githubusercontent.com/7711142/197766545-5311a191-8996-4142-92a6-c65fc151419f.png)

